### PR TITLE
Encrypt stored API keys and add migration script

### DIFF
--- a/db.py
+++ b/db.py
@@ -12,17 +12,16 @@ def get_user_by_telegram_id(telegram_id: int, session: BaseSession):
 def create_or_update_user(telegram_id: int, api_key: str, session: BaseSession):
     user = get_user_by_telegram_id(telegram_id, session)
     if user is None:
-        user = User(telegram_id=telegram_id, api_key=api_key)
+        user = User(telegram_id=telegram_id)
         session.add(user)
-    else:
-        user.api_key = api_key
+    user.set_api_key(api_key)
     session.commit()
     return user
 
 def update_user_api_key(telegram_id: int, api_key: str, session: BaseSession):
     user = get_user_by_telegram_id(telegram_id, session)
     if user:
-        user.api_key = api_key
+        user.set_api_key(api_key)
         session.commit()
 
 def update_user_model(telegram_id: int, model_id: str, max_tokens: int, session: BaseSession):

--- a/encryption.py
+++ b/encryption.py
@@ -1,0 +1,66 @@
+"""Utilities for encrypting and decrypting sensitive values."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+
+
+class EncryptionKeyMissingError(RuntimeError):
+    """Raised when the Fernet key is not configured."""
+
+
+class DecryptionError(RuntimeError):
+    """Raised when a value cannot be decrypted."""
+
+
+def _load_key() -> bytes:
+    key = os.getenv("ENCRYPTION_KEY")
+    if not key:
+        raise EncryptionKeyMissingError(
+            "Environment variable ENCRYPTION_KEY must be set with a valid Fernet key."
+        )
+    if isinstance(key, str):
+        key_bytes = key.encode("utf-8")
+    else:
+        key_bytes = key
+    return key_bytes
+
+
+@lru_cache(maxsize=1)
+def _get_cipher() -> Fernet:
+    return Fernet(_load_key())
+
+
+def encrypt_api_key(api_key: Optional[str]) -> Optional[str]:
+    """Encrypt a plain API key using the configured Fernet cipher."""
+    if api_key is None:
+        return None
+    cipher = _get_cipher()
+    encrypted = cipher.encrypt(api_key.encode("utf-8"))
+    return encrypted.decode("utf-8")
+
+
+def decrypt_api_key(encrypted_api_key: Optional[str]) -> Optional[str]:
+    """Decrypt an API key previously encrypted with :func:`encrypt_api_key`."""
+    if encrypted_api_key is None:
+        return None
+    cipher = _get_cipher()
+    try:
+        decrypted = cipher.decrypt(encrypted_api_key.encode("utf-8"))
+    except InvalidToken as exc:  # pragma: no cover - specific to cryptography internals
+        raise DecryptionError("Failed to decrypt API key.") from exc
+    return decrypted.decode("utf-8")
+
+
+def is_encrypted_api_key(value: Optional[str]) -> bool:
+    """Best-effort check whether the provided value is already encrypted."""
+    if not value:
+        return False
+    try:
+        decrypt_api_key(value)
+    except DecryptionError:
+        return False
+    return True

--- a/migrate_encrypt_api_keys.py
+++ b/migrate_encrypt_api_keys.py
@@ -1,0 +1,59 @@
+"""Migration script to encrypt existing API keys stored in plaintext."""
+from __future__ import annotations
+
+import logging
+from typing import Tuple
+
+from sqlalchemy.orm import Session
+
+from db import SessionLocal
+from encryption import DecryptionError, EncryptionKeyMissingError
+from models import User
+
+logger = logging.getLogger(__name__)
+
+
+def _process_user(user: User, session: Session) -> bool:
+    stored_value = user.api_key_encrypted
+    if not stored_value:
+        return False
+    try:
+        # If decryption succeeds, the value is already encrypted with the active key.
+        _ = user.api_key  # Access triggers decryption.
+        return False
+    except DecryptionError:
+        # Value is likely stored in plaintext, so re-encrypt it using the helper.
+        user.set_api_key(stored_value)
+        session.add(user)
+        return True
+
+
+def migrate() -> Tuple[int, int]:
+    """Encrypt plaintext API keys for all users.
+
+    Returns a tuple with the number of processed users and how many of them were updated.
+    """
+    processed = 0
+    updated = 0
+    with SessionLocal() as session:
+        users = session.query(User).all()
+        for user in users:
+            processed += 1
+            if _process_user(user, session):
+                updated += 1
+        session.commit()
+    return processed, updated
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    try:
+        processed, updated = migrate()
+    except EncryptionKeyMissingError as exc:
+        logger.error("Не удалось выполнить миграцию: %s", exc)
+        raise SystemExit(1) from exc
+    logger.info("Миграция завершена. Обработано пользователей: %s, обновлено: %s", processed, updated)
+
+
+if __name__ == "__main__":
+    main()

--- a/models.py
+++ b/models.py
@@ -1,8 +1,12 @@
 #models.py
+from typing import Optional
+
 from sqlalchemy import create_engine, Column, Integer, String, Boolean, Text, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker, Session
+
 from config import DATABASE_URL
+from encryption import decrypt_api_key, encrypt_api_key
 
 Base = declarative_base()
 
@@ -10,12 +14,34 @@ class User(Base):
     __tablename__ = 'users'
     id = Column(Integer, primary_key=True)
     telegram_id = Column(Integer, unique=True, nullable=False)
-    api_key = Column(String(250), nullable=True)
+    _api_key_encrypted = Column("api_key", String(250), nullable=True)
     model_id = Column(String(250), nullable=True)  # Поле для хранения выбранной модели
     max_tokens = Column(Integer, nullable=True)  # Поле для хранения max_tokens
     is_valid = Column(Boolean, default=True)  # Добавленное поле для индикации валидности API ключа
 
     messages = relationship("Message", back_populates="user", cascade="all, delete-orphan")
+
+    def set_api_key(self, api_key: Optional[str]) -> None:
+        """Store the provided API key in encrypted form."""
+        if api_key is None:
+            self._api_key_encrypted = None
+        else:
+            self._api_key_encrypted = encrypt_api_key(api_key)
+
+    @property
+    def api_key(self) -> Optional[str]:
+        """Return the decrypted API key for application use."""
+        if not self._api_key_encrypted:
+            return None
+        return decrypt_api_key(self._api_key_encrypted)
+
+    @property
+    def api_key_encrypted(self) -> Optional[str]:
+        """Expose the stored encrypted API key value."""
+        return self._api_key_encrypted
+
+    def has_api_key(self) -> bool:
+        return bool(self._api_key_encrypted)
 
 class Message(Base):
     __tablename__ = 'messages'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-telegram-bot==13.7
 SQLAlchemy==1.4.22
 requests==2.25.1
+cryptography>=41.0.0


### PR DESCRIPTION
## Summary
- add a Fernet-based encryption utility that loads the key from the ENCRYPTION_KEY environment variable
- store and retrieve API keys in encrypted form through the SQLAlchemy model and update bot logic to decrypt before use
- provide a migration script for existing plaintext keys and document the new cryptography dependency

## Testing
- pip install -r requirements.txt
- python - <<'PY'
from db import SessionLocal, create_or_update_user, get_user_by_telegram_id, update_user_api_key
from models import User
from migrate_encrypt_api_keys import migrate

TEST_USER_ID = 999001
UPDATED_USER_ID = 999002

with SessionLocal() as session:
    user = create_or_update_user(TEST_USER_ID, 'plain-test-key', session)
    stored = get_user_by_telegram_id(TEST_USER_ID, session)
    print('Stored encrypted differs from plain:', stored.api_key_encrypted != 'plain-test-key')
    print('Decrypted API key matches original:', stored.api_key == 'plain-test-key')

    update_user_api_key(TEST_USER_ID, 'second-key', session)
    session.refresh(stored)
    print('Updated decrypted API key matches new value:', stored.api_key == 'second-key')

with SessionLocal() as session:
    legacy_user = User(telegram_id=UPDATED_USER_ID)
    # Simulate legacy plaintext storage
    setattr(legacy_user, '_api_key_encrypted', 'legacy-plain-key')
    session.add(legacy_user)
    session.commit()

processed, updated = migrate()
print('Migration processed/updated:', processed, updated)

with SessionLocal() as session:
    migrated_user = get_user_by_telegram_id(UPDATED_USER_ID, session)
    print('Legacy value encrypted:', migrated_user.api_key_encrypted != 'legacy-plain-key')
    print('Legacy decrypted matches original:', migrated_user.api_key == 'legacy-plain-key')
PY

------
https://chatgpt.com/codex/tasks/task_e_68cb2db61400832c96b5b83ee078073e