### PR TITLE
Align message roles for OpenRouter history

### DIFF
--- a/openrouter.py
+++ b/openrouter.py
@@ -9,11 +9,8 @@ def send_to_openrouter(message, api_key, model_id, max_tokens=4096, message_hist
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json"
     }
-    messages_payload = [{"role": "user", "content": message}]
-    # Добавляем историю сообщений в payload, если она передана
-    if message_history:
-        history_payload = [{"role": "system", "content": msg} for msg in message_history]
-        messages_payload = history_payload + messages_payload
+    messages_payload = list(message_history) if message_history else []
+    messages_payload.append({"role": "user", "content": message})
 
     payload = {
         "model": model_id,


### PR DESCRIPTION
## Summary
- convert stored chat history into role-tagged message dictionaries before calling OpenRouter
- update OpenRouter client to accept pre-tagged histories and append the current user prompt

## Testing
- `python - <<'PY'
from unittest.mock import patch, MagicMock
from openrouter import send_to_openrouter

history = []
for i in range(10):
    if i % 2 == 0:
        history.append({"role": "user", "content": f"User message {i}"})
    else:
        history.append({"role": "assistant", "content": f"Assistant reply {i}"})

with patch('openrouter.requests.post') as mock_post:
    mock_response = MagicMock()
    mock_response.raise_for_status.return_value = None
    mock_response.json.return_value = {"choices": [{"message": {"content": "Simulated response"}}]}
    mock_post.return_value = mock_response

    response = send_to_openrouter("Final question", "test", "model", message_history=history)

    payload = mock_post.call_args[1]['json']
    print('Total messages:', len(payload['messages']))
    print('Roles order:', [msg['role'] for msg in payload['messages']])
    print('Response:', response)
PY`
- `python -m compileall main.py openrouter.py`


------
https://chatgpt.com/codex/tasks/task_e_68cb2dafd360832caa82a6b2511b5885