### PR TITLE
Add async API key validation and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 python-telegram-bot==13.7
 SQLAlchemy==1.4.22
 requests==2.25.1
+httpx==0.24.1
+pytest==7.4.4

--- a/tests/test_validate_api_key.py
+++ b/tests/test_validate_api_key.py
@@ -1,0 +1,108 @@
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import main
+
+
+class DummyResponse:
+    def __init__(self, status_code, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+def _patch_async_client(monkeypatch, response):
+    captured = {}
+
+    class DummyAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, headers=None):
+            captured["url"] = url
+            captured["headers"] = headers
+            return response
+
+    monkeypatch.setattr(main.httpx, "AsyncClient", lambda *args, **kwargs: DummyAsyncClient())
+    return captured
+
+
+def _create_session_with_user():
+    user = types.SimpleNamespace(is_valid=None)
+    session = MagicMock()
+    query = session.query.return_value
+    filtered = query.filter.return_value
+    filtered.first.return_value = user
+    return session, user
+
+
+def test_validate_api_key_success(monkeypatch):
+    response = DummyResponse(200, "ok")
+    captured = _patch_async_client(monkeypatch, response)
+    session, user = _create_session_with_user()
+
+    is_valid, error_message = main.validate_api_key("secret", 123, session)
+
+    assert is_valid is True
+    assert error_message is None
+    assert user.is_valid is True
+    session.commit.assert_called_once()
+    assert captured["url"] == main.API_VALIDATE_URL
+    assert captured["headers"]["Authorization"] == "Bearer secret"
+
+
+def test_validate_api_key_unauthorized(monkeypatch):
+    response = DummyResponse(401, "unauthorized")
+    _patch_async_client(monkeypatch, response)
+    session, user = _create_session_with_user()
+
+    is_valid, error_message = main.validate_api_key("bad", 123, session)
+
+    assert is_valid is False
+    assert "недействителен" in error_message
+    assert user.is_valid is False
+    session.commit.assert_called_once()
+
+
+def test_validate_api_key_server_error(monkeypatch):
+    response = DummyResponse(500, "server error")
+    _patch_async_client(monkeypatch, response)
+    session, user = _create_session_with_user()
+
+    is_valid, error_message = main.validate_api_key("test", 123, session)
+
+    assert is_valid is False
+    assert "500" in error_message
+    assert user.is_valid is False
+    session.commit.assert_called_once()
+
+
+def test_validate_api_key_http_error(monkeypatch):
+    def raise_http_error(*args, **kwargs):
+        raise main.httpx.HTTPError("network error")
+
+    class DummyAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, headers=None):
+            return raise_http_error()
+
+    monkeypatch.setattr(main.httpx, "AsyncClient", lambda *args, **kwargs: DummyAsyncClient())
+    session, user = _create_session_with_user()
+
+    is_valid, error_message = main.validate_api_key("test", 123, session)
+
+    assert is_valid is False
+    assert "Не удалось проверить API ключ" in error_message
+    assert user.is_valid is False
+    session.commit.assert_called_once()


### PR DESCRIPTION
## Summary
- switch API key validation to use the configured validation endpoint with Authorization headers via an async httpx client
- surface detailed validation results to users and update database state consistently through the synchronous wrapper
- add unit tests covering valid, unauthorized, error responses and httpx failures while updating dependencies for httpx and pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb2dae9b74832c863daeec70d3aa04